### PR TITLE
fix(v2): add USDT_MATIC swap support

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -40,6 +40,7 @@ function assetToTicker(asset: AssetId): Ticker {
         case AssetId.BTC: return Ticker.BTC;
         case AssetId.BTC_LN: return Ticker.BTC;
         case AssetId.USDC_MATIC: return Ticker.USDC;
+        case AssetId.USDT_MATIC: return Ticker.USDT;
         case AssetId.EUR: return Ticker.EUR;
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export enum Ticker {
     NIM = 'NIM',
     BTC = 'BTC',
     USDC = 'USDC',
+    USDT = 'USDT',
     // USDC_e = 'USDC.e',
     EUR = 'EUR',
 }
@@ -19,6 +20,7 @@ export enum AssetId {
     BTC = 'BTC',
     BTC_LN = 'BTC_LN',
     USDC_MATIC = 'USDC_MATIC',
+    USDT_MATIC = 'USDT_MATIC',
     EUR = 'EUR',
 }
 
@@ -35,6 +37,7 @@ export const Precision = {
     [Ticker.NIM]: 5,
     [Ticker.BTC]: 8,
     [Ticker.USDC]: 6,
+    [Ticker.USDT]: 6,
     [Ticker.EUR]: 2,
     [ReferenceAsset.USD]: 2,
 } as const;


### PR DESCRIPTION
## Summary
- add `Ticker.USDT` to the v2 API surface
- add `AssetId.USDT_MATIC` and `Precision.USDT = 6`
- map `AssetId.USDT_MATIC` to `Ticker.USDT` during quote conversion

## Verification
- `npm run prepare`
- verified the generated `dist` output contains the missing USDT symbols from #7

Closes #7